### PR TITLE
Allow computed properties to be set when instantiating a model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "manikin-model",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manikin-model",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A JS library for defining clear, reliable, flexible, and enforceable data models.",
   "files": [
     "dist"

--- a/src/classes/ManikinObject.js
+++ b/src/classes/ManikinObject.js
@@ -6,25 +6,42 @@
  */
 class ManikinObject {
   /**
+   * An internal flag to indicate if the constructor has finished running. We may want to behave
+   * differently in situations dispatched by the constructor as opposed to other situations.
+   * @type {Boolean}
+   */
+  __constructed = false;
+
+  /**
    * Apply all of the initial values when instantiating a model.
    *
    * @param {Object} initialValues An object containing default values and defining the schema of the mdoel
    */
-  constructor(initialValues) {
-    // Get the default values defined by the model and join them with the initial values
-    const values = Object.assign({}, this.__getDefaults(), initialValues);
+  constructor(initialValues = {}) {
+    const applyValues = values => {
+      Object.keys(values).forEach(key => {
+        const value = values[key];
 
-    // Apply each value
-    Object.keys(values).forEach(key => {
-      const value = values[key];
+        // Functions are added directly, while properties are added via set
+        if (typeof value === 'function') {
+          this[key] = value;
+        } else {
+          this._set(key, value);
+        }
+      });
+    };
 
-      // Functions are added directly, while properties are added via set
-      if (typeof value === 'function') {
-        this[key] = value;
-      } else {
-        this._set(key, value);
-      }
-    });
+    // Apply each default value
+    applyValues(this.__getDefaults());
+
+    // Apply overrides after the defaults have been applied to ensure the initialValues are applied
+    // on top of the defaults. This is particularly important for computed properties since, if we
+    // applied combined values at once, a computed property may manipulate some other value that
+    // could then be overwritten by a default value depending on the order of the keys.
+    applyValues(initialValues);
+
+    // Update the constructed flag to indicate that the constructor is done
+    this.__constructed = true;
   }
 
   /**
@@ -66,15 +83,16 @@ class ManikinObject {
    * Sets a value on the object instead of making a copy with updated values. Used internally.
    * @param {String} propertyName The name of the property that you want to set
    * @param {*} value The value to set the property to
-   * @return {ManikinObject} newInstance The new value to apply to the property
+   * @param {ManikinObject} instance The instance of a manikin object to update
+   * @return {ManikinObject} The updated manikin object
    * @private
    */
-  _set(propertyName, value) {
+  _set(propertyName, value, instance = this) {
     // Properties are stored by prefixing them with `__`.
     // This keeps them separate from methods and class functionality. It also makes it less
     // tempting to access properties directly and circumventing `get` and `set`
-    this[`__${propertyName}`] = value;
-    return value;
+    instance[`__${propertyName}`] = value;
+    return instance;
   }
 
   /**
@@ -84,15 +102,14 @@ class ManikinObject {
    * @param {*} value The value to set the property to
    * @return {ManikinObject} newInstance The new value to apply to the property
    */
-  set(propertyName, value) {
+  set(propertyName, value, ...rest) {
     // Like Immutable, when we set a value, return a new updated version rather than modifying
     // an existing object.
     const newInstance = Object.assign(
       Object.create(Object.getPrototypeOf(this)),
       this
     );
-    newInstance._set(propertyName, value);
-    return newInstance;
+    return newInstance._set(propertyName, value, newInstance, ...rest);
   }
 
   /**
@@ -104,14 +121,24 @@ class ManikinObject {
   setProperties(values) {
     // Like Immutable, when we set a value, return a new updated version rather than modifying
     // an existing object.
-    const newInstance = Object.assign(
-      Object.create(Object.getPrototypeOf(this)),
-      this
-    );
+
+    // If we are still constructing the object, apply values directly to this
+    let instance = this;
+
+    // If the object has already been constructed, create a copy of this, and apply values there for
+    // immutability.
+    if (this.__constructed) {
+      instance = Object.assign(
+        Object.create(Object.getPrototypeOf(this)),
+        this
+      );
+    }
+
+    // Set each value provided
     Object.keys(values).forEach(propertyName =>
-      newInstance._set(propertyName, values[propertyName])
+      instance._set(propertyName, values[propertyName], instance)
     );
-    return newInstance;
+    return instance;
   }
 
   /**

--- a/src/methods/computed.md
+++ b/src/methods/computed.md
@@ -55,3 +55,34 @@ modelInstance.get('fullName'); // 'Freddie Mercury'
 modelInstance.get('firstName'); // 'Freddie'
 modelInstance.get('lastName'); // 'Mercury'
 ```
+
+Computed properties with a setter can also be set when the model is instaniated.
+
+```javascript
+const myModel = createModel('MyModel', {
+    firstName: '',
+    lastName: '',
+    fullName: computed({
+        get() {
+            return this.get('firstName') + ' ' + this.get('lastName');
+        },
+        set(value) {
+            const names = value.split[' '];
+
+            // Manikin models are immutable, so the set must be returned
+            return this.setProperties({
+                firstName: names[0],
+                lastName: names[1],
+            });
+        },
+    }),
+});
+
+let modelInstance = new myModel({
+    fullName: 'Freddie Mercury',
+});
+
+modelInstance.get('fullName'); // 'Freddie Mercury'
+modelInstance.get('firstName'); // 'Freddie'
+modelInstance.get('lastName'); // 'Mercury'
+```

--- a/src/plugins/__tests__/computedProperties.test.js
+++ b/src/plugins/__tests__/computedProperties.test.js
@@ -221,5 +221,31 @@ describe('set', () => {
         })
       ).toThrow();
     });
+    it('computes computed properties when the object is instantiated', () => {
+      expect.assertions(3);
+      const MyModel = createModel('MyModel', {
+        firstName: '',
+        lastName: '',
+        foo: 'bar',
+        fullName: computed({
+          get() {
+            return `${this.get('firstName')} ${this.get('lastName')}`;
+          },
+          set(value) {
+            const names = value.split(' ');
+            return this.setProperties({
+              firstName: `${names[0]}`,
+              lastName: `${names[1]}`
+            });
+          }
+        })
+      });
+      const myInstance = new MyModel({
+        fullName: 'Lil Wayne'
+      });
+      expect(myInstance.get('firstName')).toEqual('Lil');
+      expect(myInstance.get('lastName')).toEqual('Wayne');
+      expect(myInstance.get('fullName')).toEqual('Lil Wayne');
+    });
   });
 });

--- a/src/plugins/__tests__/propTypes.test.js
+++ b/src/plugins/__tests__/propTypes.test.js
@@ -2,301 +2,302 @@ import PropTypes from 'prop-types';
 import { createModel, computed } from '../../index';
 
 describe('development', () => {
-    describe('get', () => {
-        it("should throw when a computed property's computation is invalid", () => {
-            const MyModel = createModel('MyModel', {
-                oneProperty: '',
-                twoProperty: '',
-                someComputedThing: computed(() => 123),
-            });
-            MyModel.prototype.propTypes = {
-                someComputedThing: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(() => myInstance.get('someComputedThing')).toThrow();
-        });
-        it("should not throw when a computed property's computation is valid", () => {
-            const MyModel = createModel('MyModel', {
-                oneProperty: '',
-                twoProperty: '',
-                someComputedThing1: computed(() => '123'),
-            });
-            MyModel.prototype.propTypes = {
-                someComputedThing1: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(myInstance.get('someComputedThing1')).toBeTruthy();
-        });
-        it("should throw when the computed property's computation is invalid after instantiation", () => {
-            const MyModel = createModel('MyModel', {
-                oneProperty: true,
-                someComputedThing2: computed(function computeSomeComputedThing() {
-                    if (this.get('oneProperty')) {
-                        return '123';
-                    }
-                    return 456;
-                }),
-            });
-            MyModel.prototype.propTypes = {
-                someComputedThing2: PropTypes.string.isRequired,
-            };
-            let myInstance = new MyModel();
-            myInstance = myInstance.set('oneProperty', false);
-            expect(() => myInstance.get('someComputedThing2')).toThrow();
-        });
+  describe('get', () => {
+    it("should throw when a computed property's computation is invalid", () => {
+      const MyModel = createModel('MyModel', {
+        oneProperty: '',
+        twoProperty: '',
+        someComputedThing: computed(() => 123)
+      });
+      MyModel.prototype.propTypes = {
+        someComputedThing: PropTypes.string.isRequired
+      };
+      expect(() => new MyModel()).toThrow();
     });
-    describe('set', () => {
-        it('should allow instantiating the model if it is defined properly', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(new MyModel()).toBeTruthy();
-        });
-        it('should allow instantating a model with invalid default properties if the invalid properties are overridden', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string.isRequired,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(new MyModel({ b: 'overriding value' })).toBeTruthy();
-        });
-        it('should throw when instantiating the model if the model schema doesnt match the proptypes', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string.isRequired,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(() => new MyModel()).toThrow();
-        });
-        it('should allow instantiating the model with valid properties', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(
-                new MyModel({
-                    a: 'new value',
-                    b: 'another new value',
-                    c: false,
-                    d: 456,
-                })
-            ).toBeTruthy();
-        });
-        it('should throw when instantiating the model with invalid properties', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(
-                () =>
-                    new MyModel({
-                        a: 456,
-                    })
-            ).toThrow();
-        });
-        it('should allow setting values that match the prop types', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(myInstance.set('a', 'new value')).toBeTruthy();
-        });
-        it('should throw when setting values that do not match the prop types', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(() => myInstance.set('c', 789)).toThrow();
-        });
-        it('allows non prop-typed properties to be set', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                stuff: '',
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(myInstance.set('stuff', 'things')).toBeTruthy();
-        });
-        it('should have an appropriate message when throwing', () => {
-            const MyModel = createModel('MyModel', {
-                e: '',
-            });
-            MyModel.prototype.propTypes = {
-                e: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(() => myInstance.set('e', 789)).toThrowError(
-                'Failed property type: Invalid property `e` of type `number` supplied to `MyModel`, expected `string`.'
-            );
-        });
-        it('should allow for instantiating a model with a computed property', () => {
-            const MyModel = createModel('MyModel', {
-                staticProperty: '',
-                someComputedThing: computed(() => 'Some Value'),
-            });
-            MyModel.prototype.propTypes = {
-                staticProperty: PropTypes.string.isRequired,
-                someComputedThing: PropTypes.string.isRequired,
-            };
-            expect(new MyModel()).toBeTruthy();
-        });
-        it('should throw when setting a computed property with an invalid value', () => {
-            const MyModel = createModel('MyModel', {
-                staticProperty: '',
-                someComputedThing4: computed({
-                    get() {
-                        return 'Some Value';
-                    },
-                    set() {},
-                }),
-            });
-            MyModel.prototype.propTypes = {
-                staticProperty: PropTypes.string.isRequired,
-                someComputedThing4: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(() => myInstance.set('someComputedThing4', 123)).toThrow();
-        });
-        it('should allow setting a computed property with a valid value', () => {
-            const MyModel = createModel('MyModel', {
-                staticProperty: '',
-                someComputedThing5: computed({
-                    get() {
-                        return 'Some Value';
-                    },
-                    set(value) {
-                        return this.set('staticProperty', value);
-                    },
-                }),
-            });
-            MyModel.prototype.propTypes = {
-                staticProperty: PropTypes.string.isRequired,
-                someComputedThing5: PropTypes.string.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(myInstance.set('someComputedThing5', 'some new value')).toBeTruthy();
-        });
+    it("should not throw when a computed property's computation is valid", () => {
+      const MyModel = createModel('MyModel', {
+        oneProperty: '',
+        twoProperty: '',
+        someComputedThing1: computed(() => '123')
+      });
+      MyModel.prototype.propTypes = {
+        someComputedThing1: PropTypes.string.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(myInstance.get('someComputedThing1')).toBeTruthy();
     });
+    it("should throw when the computed property's computation is invalid after instantiation", () => {
+      const MyModel = createModel('MyModel', {
+        oneProperty: true,
+        someComputedThing2: computed(function computeSomeComputedThing() {
+          if (this.get('oneProperty')) {
+            return '123';
+          }
+          return 456;
+        })
+      });
+      MyModel.prototype.propTypes = {
+        someComputedThing2: PropTypes.string.isRequired
+      };
+      let myInstance = new MyModel();
+      myInstance = myInstance.set('oneProperty', false);
+      expect(() => myInstance.get('someComputedThing2')).toThrow();
+    });
+  });
+  describe('set', () => {
+    it('should allow instantiating the model if it is defined properly', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(new MyModel()).toBeTruthy();
+    });
+    it('should allow instantating a model with invalid default properties if the invalid properties are overridden', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(new MyModel({ b: 'overriding value' })).toBeTruthy();
+    });
+    it('should throw when instantiating the model if the model schema doesnt match the proptypes', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(() => new MyModel()).toThrow();
+    });
+    it('should allow instantiating the model with valid properties', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(
+        new MyModel({
+          a: 'new value',
+          b: 'another new value',
+          c: false,
+          d: 456
+        })
+      ).toBeTruthy();
+    });
+    it('should throw when instantiating the model with invalid properties', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(
+        () =>
+          new MyModel({
+            a: 456
+          })
+      ).toThrow();
+    });
+    it('should allow setting values that match the prop types', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(myInstance.set('a', 'new value')).toBeTruthy();
+    });
+    it('should throw when setting values that do not match the prop types', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(() => myInstance.set('c', 789)).toThrow();
+    });
+    it('allows non prop-typed properties to be set', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        stuff: ''
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(myInstance.set('stuff', 'things')).toBeTruthy();
+    });
+    it('should have an appropriate message when throwing', () => {
+      const MyModel = createModel('MyModel', {
+        e: ''
+      });
+      MyModel.prototype.propTypes = {
+        e: PropTypes.string.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(() => myInstance.set('e', 789)).toThrowError(
+        'Failed property type: Invalid property `e` of type `number` supplied to `MyModel`, expected `string`.'
+      );
+    });
+    it('should allow for instantiating a model with a computed property', () => {
+      const MyModel = createModel('MyModel', {
+        staticProperty: '',
+        someComputedThing: computed(() => 'Some Value')
+      });
+      MyModel.prototype.propTypes = {
+        staticProperty: PropTypes.string.isRequired,
+        someComputedThing: PropTypes.string.isRequired
+      };
+      expect(new MyModel()).toBeTruthy();
+    });
+    it('should throw when setting a computed property with an invalid value', () => {
+      const MyModel = createModel('MyModel', {
+        staticProperty: '',
+        someComputedThing4: computed({
+          get() {
+            return 'Some Value';
+          },
+          set() {}
+        })
+      });
+      MyModel.prototype.propTypes = {
+        staticProperty: PropTypes.string.isRequired,
+        someComputedThing4: PropTypes.string.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(() => myInstance.set('someComputedThing4', 123)).toThrow();
+    });
+    it('should allow setting a computed property with a valid value', () => {
+      const MyModel = createModel('MyModel', {
+        staticProperty: '',
+        someComputedThing5: computed({
+          get() {
+            return 'Some Value';
+          },
+          set(value) {
+            return this.set('staticProperty', value);
+          }
+        })
+      });
+      MyModel.prototype.propTypes = {
+        staticProperty: PropTypes.string.isRequired,
+        someComputedThing5: PropTypes.string.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(
+        myInstance.set('someComputedThing5', 'some new value')
+      ).toBeTruthy();
+    });
+  });
 });
 
 describe('production', () => {
-    beforeEach(() => {
-        process.env.NODE_ENV = 'production';
-    });
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+  });
 
-    afterEach(() => {
-        delete process.env.NODE_ENV;
-    });
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
 
-    describe('set', () => {
-        it('should not throw when instantiating the model if the model schema doesnt match the proptypes', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string.isRequired,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(new MyModel()).toBeTruthy();
-        });
-        it('should not throw when instantiating the model with invalid properties', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            expect(
-                new MyModel({
-                    a: 456,
-                })
-            ).toBeTruthy();
-        });
-        it('should not throw when setting values that do not match the prop types', () => {
-            const MyModel = createModel('MyModel', {
-                a: '',
-                b: null,
-                c: true,
-                d: 123,
-            });
-            MyModel.prototype.propTypes = {
-                a: PropTypes.string.isRequired,
-                b: PropTypes.string,
-                c: PropTypes.bool.isRequired,
-                d: PropTypes.number.isRequired,
-            };
-            const myInstance = new MyModel();
-            expect(myInstance.set('c', 789)).toBeTruthy();
-        });
+  describe('set', () => {
+    it('should not throw when instantiating the model if the model schema doesnt match the proptypes', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(new MyModel()).toBeTruthy();
     });
+    it('should not throw when instantiating the model with invalid properties', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      expect(
+        new MyModel({
+          a: 456
+        })
+      ).toBeTruthy();
+    });
+    it('should not throw when setting values that do not match the prop types', () => {
+      const MyModel = createModel('MyModel', {
+        a: '',
+        b: null,
+        c: true,
+        d: 123
+      });
+      MyModel.prototype.propTypes = {
+        a: PropTypes.string.isRequired,
+        b: PropTypes.string,
+        c: PropTypes.bool.isRequired,
+        d: PropTypes.number.isRequired
+      };
+      const myInstance = new MyModel();
+      expect(myInstance.set('c', 789)).toBeTruthy();
+    });
+  });
 });

--- a/src/plugins/computedProperties.js
+++ b/src/plugins/computedProperties.js
@@ -25,18 +25,18 @@ const computedPropertiesPlugin = function computedPropertiesPlugin(
       return value;
     }
 
-    // Extend Manikin's set method so that it will evaluate computed setters or notify about
-    // setting readonly computed properties
-    set(propertyName, value, ...rest) {
+    // Extend Manikin's private _set method so that it will evaluate computed setters or notify
+    // about setting readonly computed properties
+    _set(propertyName, value, instance = this, ...rest) {
       // Get the property from the default values instead of using get, because we just need
       // to check the type, and the stored value may not be set yet.
-      const originalValue = this.__getDefaults()[propertyName];
+      const originalValue = instance.__getDefaults()[propertyName];
 
       // If the property is a computed property, and it has been set, then continue
       // with the computed property logic
       if (
         originalValue instanceof ComputedProperty &&
-        this[`__${propertyName}`]
+        instance[`__${propertyName}`]
       ) {
         // Throw an error if the computed property doesn't have a setter
         if (!originalValue.handleSet) {
@@ -46,17 +46,17 @@ const computedPropertiesPlugin = function computedPropertiesPlugin(
         }
 
         // Run the setter
-        return originalValue.handleSet.bind(this)(value, ...rest);
+        return originalValue.handleSet.bind(instance)(value, ...rest);
       }
 
       // If the value is not a computed property or has not yet been set, set the value as
       // usual. This is done to account for `set` being called for each property within
       // the ManikinObject constructor
-      return super.set(propertyName, value, ...rest);
+      return super._set(propertyName, value, instance, ...rest);
     }
 
-    // Extend Manikin's _set method so that it will evaluate computed setters or notify about
-    // setting readonly computed properties when setProperties is used
+    // Extend Manikin's setProperties method so that it will evaluate computed setters or notify
+    // about setting readonly computed properties when setProperties is used
     setProperties(values, ...rest) {
       const defaults = this.__getDefaults();
 


### PR DESCRIPTION
BREAKING CHANGE: computed properties will now have their proptypes checked immediately when the model is instantiated. Previously, computed properties would not be checked until the consumer attempts to get them.